### PR TITLE
Save domain dependent values in domain.conf

### DIFF
--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -75,3 +75,4 @@ dns_selfhost_rm() {
   _debug txtvalue "$txt"
   _info "Creating and removing of records is not supported by selfhost API, will not delete anything."
 }
+

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -75,4 +75,3 @@ dns_selfhost_rm() {
   _debug txtvalue "$txt"
   _info "Creating and removing of records is not supported by selfhost API, will not delete anything."
 }
-

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -19,6 +19,11 @@ dns_selfhost_add() {
   SELFHOSTDNS_RID2="${SELFHOSTDNS_RID2:-$(_readaccountconf_mutable SELFHOSTDNS_RID2)}"
   SELFHOSTDNS_LAST_SLOT="$(_readaccountconf_mutable SELFHOSTDNS_LAST_SLOT)"
 
+  if [ -z "${SELFHOSTDNS_USERNAME:-}" ] || [ -z "${SELFHOSTDNS_PASSWORD:-}" ]; then
+    _err "SELFHOSTDNS_USERNAME and SELFHOSTDNS_PASSWORD must be set"
+    return 1
+  fi
+
   if test -z "$SELFHOSTDNS_LAST_SLOT"; then
     SELFHOSTDNS_LAST_SLOT=1
   fi
@@ -39,6 +44,11 @@ dns_selfhost_add() {
       rid=$SELFHOSTDNS_RID2
       SELFHOSTDNS_LAST_SLOT=2
     fi
+  fi
+
+  if test -z "$rid"; then
+    _err "SELFHOSTDNS_RID and SELFHOSTDNS_RID2, or SELFHOSTDNS_MAP must be set"
+    return 1
   fi
 
   _saveaccountconf_mutable SELFHOSTDNS_LAST_SLOT "$SELFHOSTDNS_LAST_SLOT"


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

I changed the access and storage of the RID values to the domain.conf. This way each domain will store and can access there dependent values to allow renewal of all domains via the acme.sh function(--renew-all). 
(Fixing behaviour: https://github.com/Marvo2011/acme.sh/issues/1#issuecomment-1104149385)

Explicitly setting the RID values before renewal is still functional and will be prioritized (only using the conf values if no export is present.


Also added some value checks to abort early with a message.
