### PR TITLE
Dev

### DIFF
--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -30,7 +30,7 @@ dns_selfhost_add() {
   # e.g. don't match mytest.example.com or sub.test.example.com for test.example.com
   # if the domain is defined multiple times only the last occurance will be matched
   mapEntry=$(echo "$SELFHOSTDNS_MAP" | sed -n -E "s/(^|^.*[[:space:]])($fulldomain)(:[[:digit:]]+)([:]?[[:digit:]]*)(.*)/\2\3\4/p")
-  _debug mapEntry $mapEntry
+  _debug mapEntry "$mapEntry"
   if test -z "$mapEntry"; then
     _err "SELFHOSTDNS_MAP must contain the fulldomain incl. prefix and at least one RID"
     return 1
@@ -38,16 +38,16 @@ dns_selfhost_add() {
 
   # get the RIDs from the map entry
   rid1=$(echo "$mapEntry" | cut -d: -f2)
-  _debug rid1 $rid1
+  _debug rid1 "$rid1"
   rid2=$(echo "$mapEntry" | cut -d: -f3)
-  _debug rid2 $rid2
+  _debug rid2 "$rid2"
 
   rid=$rid1
   # check for wildcard domain and use rid2 if set
   if _startswith "$d" '*.'; then
     _debug2 "wildcard domain"
     if ! test -z "$rid2"; then
-      rid=$rid2
+      rid="$rid2"
     fi
   fi
 

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -4,8 +4,6 @@
 #       Report Bugs here: https://github.com/Marvo2011/acme.sh/issues/1
 #	Last Edit: 17.02.2022
 
-DNS_CHALLENGE_PREFIX_ESCAPED="_acme-challenge\."
-
 dns_selfhost_add() {
   fulldomain=$1
   txt=$2
@@ -33,16 +31,12 @@ dns_selfhost_add() {
     SELFHOSTDNS_LAST_SLOT=1
   fi
 
-  # cut DNS_CHALLENGE_PREFIX_ESCAPED from fulldomain if present at the beginning of the string
-  lookupdomain=$(echo "$fulldomain" | sed "s/^$DNS_CHALLENGE_PREFIX_ESCAPED//")
-  _debug lookupdomain "$lookupdomain"
-
-  # get the RID for lookupdomain or fulldomain from SELFHOSTDNS_MAP
+  # get the RID for fulldomain from SELFHOSTDNS_MAP
   # only match full domains (at the beginning of the string or with a leading whitespace),
   # e.g. don't match mytest.example.com or sub.test.example.com for test.example.com
   # replace the whole string with the RID (matching group 3) for assignment
   # if the domain is defined multiple times only the last occurance will be matched
-  rid=$(echo "$SELFHOSTDNS_MAP" | sed -E "s/(^|^.*[[:space:]])($lookupdomain:|$fulldomain:)([0-9][0-9]*)(.*)/\3/")
+  rid=$(echo "$SELFHOSTDNS_MAP" | sed -E "s/(^|^.*[[:space:]])($fulldomain:)([0-9][0-9]*)(.*)/\3/")
 
   if test -z "$rid"; then
     if [ $SELFHOSTDNS_LAST_SLOT = "2" ]; then

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -18,7 +18,7 @@ dns_selfhost_add() {
   SELFHOSTDNS_PASSWORD="${SELFHOSTDNS_PASSWORD:-$(_readaccountconf_mutable SELFHOSTDNS_PASSWORD)}"
   # These values are domain dependent, so read them from there
   SELFHOSTDNS_MAP="${SELFHOSTDNS_MAP:-$(_readdomainconf SELFHOSTDNS_MAP)}"
-  # Selfhost api can't dynamically add TXT record, 
+  # Selfhost api can't dynamically add TXT record,
   # so we have to store the last used RID of the domain to support a second RID for wildcard domains
   # (format: ';fulldomainA:lastRid;;fulldomainB:lastRid;...')
   SELFHOSTDNS_MAP_LAST_USED_INTERNAL=$(_readdomainconf SELFHOSTDNS_MAP_LAST_USED_INTERNAL)
@@ -56,11 +56,10 @@ dns_selfhost_add() {
   if ! test -z "$lastUsedRidForDomainEntry"; then
     # replace last used rid entry for domain
     SELFHOSTDNS_MAP_LAST_USED_INTERNAL=$(echo "$SELFHOSTDNS_MAP_LAST_USED_INTERNAL" | sed -n -E "s/$lastUsedRidForDomainEntry/;$fulldomain:$rid;/p")
-  else 
+  else
     # add last used rid entry for domain
     SELFHOSTDNS_MAP_LAST_USED_INTERNAL="$SELFHOSTDNS_MAP_LAST_USED_INTERNAL"";$fulldomain:$rid;"
   fi
-
 
   _info "Trying to add $txt on selfhost for rid: $rid"
 

--- a/dnsapi/dns_selfhost.sh
+++ b/dnsapi/dns_selfhost.sh
@@ -17,10 +17,10 @@ dns_selfhost_add() {
   SELFHOSTDNS_USERNAME="${SELFHOSTDNS_USERNAME:-$(_readaccountconf_mutable SELFHOSTDNS_USERNAME)}"
   SELFHOSTDNS_PASSWORD="${SELFHOSTDNS_PASSWORD:-$(_readaccountconf_mutable SELFHOSTDNS_PASSWORD)}"
   # These values are domain dependent, so read them from there
-  _getdeployconf SELFHOSTDNS_MAP
-  _getdeployconf SELFHOSTDNS_RID
-  _getdeployconf SELFHOSTDNS_RID2
-  _getdeployconf SELFHOSTDNS_LAST_SLOT
+  SELFHOSTDNS_MAP="${SELFHOSTDNS_MAP:-$(_readdomainconf SELFHOSTDNS_MAP)}"
+  SELFHOSTDNS_RID="${SELFHOSTDNS_RID:-$(_readdomainconf SELFHOSTDNS_RID)}"
+  SELFHOSTDNS_RID2="${SELFHOSTDNS_RID2:-$(_readdomainconf SELFHOSTDNS_RID2)}"
+  SELFHOSTDNS_LAST_SLOT="${SELFHOSTDNS_LAST_SLOT:-$(_readdomainconf SELFHOSTDNS_LAST_SLOT)}"
 
   if [ -z "${SELFHOSTDNS_USERNAME:-}" ] || [ -z "${SELFHOSTDNS_PASSWORD:-}" ]; then
     _err "SELFHOSTDNS_USERNAME and SELFHOSTDNS_PASSWORD must be set"
@@ -67,10 +67,10 @@ dns_selfhost_add() {
   _saveaccountconf_mutable SELFHOSTDNS_USERNAME "$SELFHOSTDNS_USERNAME"
   _saveaccountconf_mutable SELFHOSTDNS_PASSWORD "$SELFHOSTDNS_PASSWORD"
   # These values are domain dependent, so store them there
-  _savedeployconf SELFHOSTDNS_MAP "$SELFHOSTDNS_MAP"
-  _savedeployconf SELFHOSTDNS_RID "$SELFHOSTDNS_RID"
-  _savedeployconf SELFHOSTDNS_RID2 "$SELFHOSTDNS_RID2"
-  _savedeployconf SELFHOSTDNS_LAST_SLOT "$SELFHOSTDNS_LAST_SLOT"
+  _savedomainconf SELFHOSTDNS_MAP "$SELFHOSTDNS_MAP"
+  _savedomainconf SELFHOSTDNS_RID "$SELFHOSTDNS_RID"
+  _savedomainconf SELFHOSTDNS_RID2 "$SELFHOSTDNS_RID2"
+  _savedomainconf SELFHOSTDNS_LAST_SLOT "$SELFHOSTDNS_LAST_SLOT"
 }
 
 dns_selfhost_rm() {


### PR DESCRIPTION
<!--
1. Do NOT send pull request to `master` branch.
Please send to `dev` branch instead.
Any PR to `master` branch will NOT be merged.

2. For dns api support, read this guide first: https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide
You will NOT get any review without passing this guide.  You also need to fix the CI errors.

-->

I implemented the fixes of the review, but these have a few implications.
- as the hardcoded prefix for the matching must be removed, the SELFHOSTDNS_MAP must contain the fulldomain including the prefix ("_acme-challenge." or any other for DNS alias mode)
- SELFHOSTDNS_RID and SELFHOSTDNS_RID2 variables have been removed as suggested. All entries must be contained in SELFHOSTDNS_MAP. Up to two RIDs per fulldomain are supported but at least one must be set, e.g. `prefix.sub.domain.net:<RID>:<RID2> prefix.sub2.domain.net:<RID> prefix.sub3.domain.net:<RID>:<RID2>`
- SELFHOSTDNS_LAST_SLOT has been removed. For wildcard support the last used RID per domain will be stored internally (SELFHOSTDNS_MAP_LAST_USED_INTERNAL) to switch between them (if two RIDs are defined). The domain and last used RID will be stored in the format ";fulldomainA:lastUsedRidForFulldomainA;;fulldomainB:lastUsedRidForFulldomainB;;fulldomainC:lastUsedRidForFulldomainC;"

The usage of only SELFHOSTDNS_MAP has the sideeffect that now the issuing of multiple wildcard domain in one cert is supported, e.g. `... -d sub.example.com -d *.sub.example.com -d sub2.example.com -d *.sub2.example.com ...`

Please review, as these changes probably break your supported plugins.
- As the user has to add the TXT entries with the fulldomain incl. prefix manually anyway, i hope this is not a big drawback